### PR TITLE
Fix: Removed Duplicate Headers in Short Data Files

### DIFF
--- a/oss_data_short/short_pull_requests.csv
+++ b/oss_data_short/short_pull_requests.csv
@@ -1,5 +1,4 @@
 ,repo_id,repo_name,data_collection_date,event_type,event_datetime,contributor_name,pr_merge_status
-,repo_id,repo_name,data_collection_date,event_type,event_datetime,contributor_name,pr_merge_status
 0,25952,yt,2023-02-28 16:46:00,pull_request_created,2023-03-27 22:07:35,neutrinoceros,not merged
 1,25888,de_rle,2023-02-28 16:46:00,pull_request_created,2020-11-09 22:12:51,dgosselin-p4,merged
 2,25880,Gklee,2023-02-28 16:46:00,pull_request_created,2021-03-23 02:09:26,tanmaytirpankar,not merged


### PR DESCRIPTION
While working with the example data found in `/oss_data_short/short_pull_requests.csv,` I found that when using pandas for data wrangling and manipulation, the function pd.to_datetime would not work with this specific CSV. After investigating the dataset, I discovered a duplicate header in this particular file. As for the changes, I removed the duplicate header on line 1 of the dataset. As for the other CSV's in the `/oss_data_short` folder, I experienced no issues.